### PR TITLE
(fix) first device permission request always fails

### DIFF
--- a/lib/src/main/java/com/serenegiant/usb/USBMonitor.java
+++ b/lib/src/main/java/com/serenegiant/usb/USBMonitor.java
@@ -168,7 +168,7 @@ public final class USBMonitor {
 			if (DEBUG) Log.i(TAG, "register:");
 			final Context context = mWeakContext.get();
 			if (context != null) {
-				mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), PendingIntent.FLAG_IMMUTABLE);
+				mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), PendingIntent.FLAG_MUTABLE);
 				final IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
 				// ACTION_USB_DEVICE_ATTACHED never comes on some devices so it should not be added here
 				filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);


### PR DESCRIPTION
This happens because of PendingIntent.FLAG_IMMUTABLE flag on the PendingIntent that causes no result to be provided at all.

Fixes #2 