### PR TITLE
(imp) UvcCameraController

### DIFF
--- a/flutter/lib/src/uvccamera_controller.dart
+++ b/flutter/lib/src/uvccamera_controller.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
-import 'package:flutter/widgets.dart';
 import 'package:cross_file/cross_file.dart';
+import 'package:flutter/widgets.dart';
 
 import 'uvccamera_button_event.dart';
 import 'uvccamera_controller_state.dart';

--- a/flutter/lib/src/uvccamera_controller.dart
+++ b/flutter/lib/src/uvccamera_controller.dart
@@ -112,56 +112,31 @@ class UvcCameraController extends ValueNotifier<UvcCameraControllerState> {
 
   /// Returns the camera ID.
   int get cameraId {
-    if (_isDisposed) {
-      throw Exception('UvcCameraController is disposed');
-    }
-    if (_cameraId == null) {
-      throw Exception('UvcCameraController is not initialized');
-    }
+    _isInitializedOrDisposed();
     return _cameraId!;
   }
 
   /// Returns the texture ID.
   int get textureId {
-    if (_isDisposed) {
-      throw Exception('UvcCameraController is disposed');
-    }
-    if (_textureId == null) {
-      throw Exception('UvcCameraController is not initialized');
-    }
+    _isInitializedOrDisposed();
     return _textureId!;
   }
 
   /// Returns a stream of camera status events.
   Stream<UvcCameraStatusEvent> get cameraStatusEvents {
-    if (_isDisposed) {
-      throw Exception('UvcCameraController is disposed');
-    }
-    if (_cameraStatusEventStream == null) {
-      throw Exception('UvcCameraController is not initialized');
-    }
+    _isInitializedOrDisposed();
     return _cameraStatusEventStream!;
   }
 
   /// Returns a stream of camera button events.
   Stream<UvcCameraButtonEvent> get cameraButtonEvents {
-    if (_isDisposed) {
-      throw Exception('UvcCameraController is disposed');
-    }
-    if (_cameraButtonEventStream == null) {
-      throw Exception('UvcCameraController is not initialized');
-    }
+    _isInitializedOrDisposed();
     return _cameraButtonEventStream!;
   }
 
   /// Starts video recording.
   Future<void> startVideoRecording(UvcCameraMode videoRecordingMode) async {
-    if (_isDisposed) {
-      throw Exception('UvcCameraController is disposed');
-    }
-    if (_cameraId == null) {
-      throw Exception('UvcCameraController is not initialized');
-    }
+    _isInitializedOrDisposed();
 
     if (value.isRecordingVideo) {
       throw Exception('UvcCameraController is already recording video');
@@ -181,12 +156,7 @@ class UvcCameraController extends ValueNotifier<UvcCameraControllerState> {
 
   /// Stops video recording.
   Future<XFile> stopVideoRecording() async {
-    if (_isDisposed) {
-      throw Exception('UvcCameraController is disposed');
-    }
-    if (_cameraId == null) {
-      throw Exception('UvcCameraController is not initialized');
-    }
+    _isInitializedOrDisposed();
 
     if (!value.isRecordingVideo) {
       throw Exception('UvcCameraController is not recording video');
@@ -207,13 +177,16 @@ class UvcCameraController extends ValueNotifier<UvcCameraControllerState> {
 
   /// Returns a widget showing a live camera preview.
   Widget buildPreview() {
+    _isInitializedOrDisposed();
+    return Texture(textureId: _textureId!);
+  }
+
+  void _isInitializedOrDisposed() {
     if (_isDisposed) {
       throw Exception('UvcCameraController is disposed');
     }
-    if (_textureId == null) {
+    if (_initializeFuture == null) {
       throw Exception('UvcCameraController is not initialized');
     }
-
-    return Texture(textureId: _textureId!);
   }
 }

--- a/flutter/lib/src/uvccamera_controller.dart
+++ b/flutter/lib/src/uvccamera_controller.dart
@@ -139,7 +139,7 @@ class UvcCameraController extends ValueNotifier<UvcCameraControllerState> {
     _isInitializedOrDisposed();
 
     if (value.isRecordingVideo) {
-      throw Exception('UvcCameraController is already recording video');
+      return;
     }
 
     final XFile videoRecordingFile = await UvcCameraPlatformInterface.instance.startVideoRecording(

--- a/flutter/lib/src/uvccamera_controller.dart
+++ b/flutter/lib/src/uvccamera_controller.dart
@@ -143,7 +143,7 @@ class UvcCameraController extends ValueNotifier<UvcCameraControllerState> {
     _isInitializedOrDisposed();
 
     if (value.isRecordingVideo) {
-      return;
+      throw Exception('UvcCameraController is already recording video');
     }
 
     final XFile videoRecordingFile = await UvcCameraPlatformInterface.instance.startVideoRecording(


### PR DESCRIPTION
It's small improvement on Controller:

- Refactor code to use `_isInitializedOrDisposed()` and avoid repetitive checks.
- `_initializeFuture` became a Completer, this way we can check if it's already completed inside dispose, avoiding unnecessary wait.
- _initializeFuture: now completes with success or with failure allowing developers to identify the cause of error.
- We now throw exception if user try to initialize the controller twice.
- Trying to record a video that is already in record mode, do nothing instead of throwing error (Flutter developers usually don't interrupt flow with Exceptions, just trying to reduce friction)


None of this code fix any bug, so it's all up to you!