### PR TITLE
(fix) UVCCamera.getPreviewSize(): compare width and height, not or

### DIFF
--- a/lib/src/main/java/com/serenegiant/usb/UVCCamera.java
+++ b/lib/src/main/java/com/serenegiant/usb/UVCCamera.java
@@ -272,7 +272,7 @@ public class UVCCamera {
 		final List<Size> list = getSupportedSizeList();
 		for (final Size sz: list) {
 			if ((sz.width == mCurrentWidth)
-				|| (sz.height == mCurrentHeight)) {
+				&& (sz.height == mCurrentHeight)) {
 				result =sz;
 				break;
 			}


### PR DESCRIPTION
Fixes #52