### PR TITLE
Implement 16 KB page size compliance for Google Play requirement

### DIFF
--- a/flutter/android/build.gradle.kts
+++ b/flutter/android/build.gradle.kts
@@ -11,10 +11,11 @@ version = run {
 
 android {
     namespace = "org.uvccamera.flutter"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 21
+        targetSdk = 35  // Android 15 for 16 KB page size compliance
     }
 
     compileOptions {

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -8,10 +8,11 @@ version = findProperty("uvccamera.version") as String? ?: "0.0.0-SNAPSHOT"
 
 android {
     namespace = "org.uvccamera.lib"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 21
+        targetSdk = 35  // Android 15 for 16 KB page size compliance
 
         testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/lib/src/main/jni/Application.mk
+++ b/lib/src/main/jni/Application.mk
@@ -30,3 +30,6 @@ APP_PLATFORM := android-21
 APP_ABI := armeabi-v7a arm64-v8a
 #APP_OPTIM := debug
 APP_OPTIM := release
+
+# Support for 16 KB page sizes (required for Google Play compliance Nov 2025)
+APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true

--- a/lib/src/main/jni/UVCCamera/Android.mk
+++ b/lib/src/main/jni/UVCCamera/Android.mk
@@ -48,6 +48,9 @@ LOCAL_LDLIBS := -L$(SYSROOT)/usr/lib -ldl
 LOCAL_LDLIBS += -llog
 LOCAL_LDLIBS += -landroid
 
+# 16 KB page size support for Google Play compliance (Nov 2025)
+LOCAL_LDFLAGS += -Wl,-z,max-page-size=16384
+
 LOCAL_SHARED_LIBRARIES += usb100 uvc
 
 LOCAL_ARM_MODE := arm

--- a/lib/src/main/jni/libjpeg-turbo-1.5.0/Android.mk
+++ b/lib/src/main/jni/libjpeg-turbo-1.5.0/Android.mk
@@ -261,6 +261,9 @@ LOCAL_DISABLE_FATAL_LINKER_WARNINGS := true
 
 LOCAL_LDLIBS := -L$(SYSROOT)/usr/lib -ldl	# to avoid NDK issue(no need for static library)
 
+# 16 KB page size support for Google Play compliance (Nov 2025)
+LOCAL_LDFLAGS += -Wl,-z,max-page-size=16384
+
 LOCAL_WHOLE_STATIC_LIBRARIES = jpeg-turbo1500_static
 
 LOCAL_MODULE := jpeg-turbo1500

--- a/lib/src/main/jni/libusb/android/jni/libusb.mk
+++ b/lib/src/main/jni/libusb/android/jni/libusb.mk
@@ -70,6 +70,9 @@ include $(CLEAR_VARS)
 LOCAL_MODULE_TAGS := optional
 LOCAL_EXPORT_LDLIBS += -llog
 
+# 16 KB page size support for Google Play compliance (Nov 2025)
+LOCAL_LDFLAGS += -Wl,-z,max-page-size=16384
+
 LOCAL_WHOLE_STATIC_LIBRARIES = libusb100_static
 
 LOCAL_MODULE := libusb100

--- a/lib/src/main/jni/libuvc/android/jni/Android.mk
+++ b/lib/src/main/jni/libuvc/android/jni/Android.mk
@@ -80,6 +80,9 @@ include $(CLEAR_VARS)
 LOCAL_MODULE_TAGS := optional
 LOCAL_EXPORT_LDLIBS += -llog
 
+# 16 KB page size support for Google Play compliance (Nov 2025)
+LOCAL_LDFLAGS += -Wl,-z,max-page-size=16384
+
 LOCAL_WHOLE_STATIC_LIBRARIES = libuvc_static
 LOCAL_DISABLE_FATAL_LINKER_WARNINGS := true
 


### PR DESCRIPTION
- Add APP_SUPPORT_FLEXIBLE_PAGE_SIZES to Application.mk
- Add 16 KB LDFLAGS to all native library Android.mk files
- Update target/compile SDK to 35 for Android 15 compliance
- All native libraries now properly aligned for 16 KB page sizes
- Validated with Google's zipalign tool: VERIFICATION SUCCESSFUL
- Addresses Google Play requirement effective November 1st, 2025