### PR TITLE
fix: align native libraries to 16 KB page boundaries for Android 15+

### DIFF
--- a/lib/src/main/jni/Application.mk
+++ b/lib/src/main/jni/Application.mk
@@ -30,3 +30,7 @@ APP_PLATFORM := android-21
 APP_ABI := armeabi-v7a arm64-v8a
 #APP_OPTIM := debug
 APP_OPTIM := release
+
+# 16 KB page size alignment for Android 15+ compatibility
+# See: https://developer.android.com/guide/practices/page-sizes
+APP_LDFLAGS := -Wl,-z,max-page-size=16384


### PR DESCRIPTION
## Problem

Android 15 introduces support for 16 KB page sizes. Devices using 16 KB pages cannot load native libraries that have ELF `LOAD` segments not aligned to 16 KB boundaries.

Currently, all four native libraries produce alignment warnings:
- `libUVCCamera.so`
- `libjpeg-turbo1500.so`
- `libusb100.so`
- `libuvc.so`

## Solution

Add `APP_LDFLAGS := -Wl,-z,max-page-size=16384` to `Application.mk`, which applies the 16 KB alignment to all native libraries at link time.

## Verification

After this change, all `LOAD` segments in the built libraries show `Align: 0x4000` (16384 bytes).

## References

- [Support 16 KB page sizes](https://developer.android.com/guide/practices/page-sizes) - Android Developers