### PR TITLE
(fix) flutter: lower minimum SDK floor to Flutter 3.24.0

### DIFF
--- a/flutter/README.md
+++ b/flutter/README.md
@@ -7,6 +7,18 @@
 A USB Video Class (UVC) camera plugin for Flutter based on [UVCCamera](https://uvccamera.org) library for Android,
 brought to you by [Alexey Pelykh](https://alexey-pelykh.com).
 
+## Compatibility
+
+**Flutter 3.29.2+ is strongly recommended.** Flutter 3.27–3.28 enabled Impeller by default on Android, which causes
+black screens on some devices (MediaTek/PowerVR GPUs). This was fixed in Flutter 3.29.0 with automatic GLES fallback
+(and a crash fix in 3.29.2). If you use Flutter 3.27.x–3.28.x and experience a black screen, disable Impeller:
+
+```xml
+<meta-data android:name="io.flutter.embedding.android.EnableImpeller" android:value="false" />
+```
+
+Flutter 3.24–3.26 users are unaffected (Impeller was not default on Android).
+
 ## Usage
 
 The plugin's API is intentionally kept similar to the [camera](https://pub.dev/packages/camera) package. See the

--- a/flutter/example/pubspec.yaml
+++ b/flutter/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: "Demonstrates how to use the uvccamera plugin."
 publish_to: none
 
 environment:
-  sdk: ^3.7.0
+  sdk: ">=3.5.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -8,8 +8,8 @@ platforms:
   android:
 
 environment:
-  sdk: ^3.7.0
-  flutter: ">=3.29.2"
+  sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary

- Lower Flutter minimum from `>=3.29.2` to `>=3.24.0` (real API boundary: `TextureRegistry.SurfaceProducer`)
- Lower Dart SDK from `^3.7.0` to `>=3.5.0 <4.0.0`
- Add Impeller compatibility note to README documenting the black screen workaround for Flutter 3.27–3.28

## Context

The 3.29.2 floor enforced an Impeller runtime fix, not an API requirement. This excluded users on Flutter 3.24–3.26 (completely unaffected by Impeller) and 3.27–3.28 (simple `EnableImpeller=false` workaround).

Closes #82
Supersedes #61
Related: #60, #39, #75

## Test plan

- [ ] Verify `flutter pub get` succeeds with the updated constraints
- [ ] Verify CI passes (build + snapshot publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)