### PR TITLE
Fix crash caused by USB device disconnection during permission grant

### DIFF
--- a/flutter/android/src/main/java/org/uvccamera/flutter/UvcCameraPlatform.java
+++ b/flutter/android/src/main/java/org/uvccamera/flutter/UvcCameraPlatform.java
@@ -386,7 +386,12 @@ import io.flutter.view.TextureRegistry;
         }
 
         // NOTE: The device is already connected, this should just retrieve the device control block
-        final var deviceCtrlBlock = usbMonitor.openDevice(device);
+        final USBMonitor.UsbControlBlock deviceCtrlBlock;
+        try {
+            deviceCtrlBlock = usbMonitor.openDevice(device);
+        } catch (final IOException e) {
+            throw new IllegalStateException("Failed to open USB device: " + deviceName, e);
+        }
 
         final var camera = new UVCCamera();
         final var cameraId = deviceCtrlBlock.getConnection().getFileDescriptor();

--- a/lib/src/main/java/com/serenegiant/usb/USBMonitor.java
+++ b/lib/src/main/java/com/serenegiant/usb/USBMonitor.java
@@ -23,6 +23,7 @@
 
 package com.serenegiant.usb;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -467,7 +468,7 @@ public final class USBMonitor {
 	 * @return
 	 * @throws SecurityException パーミッションがなければSecurityExceptionを投げる
 	 */
-	public UsbControlBlock openDevice(final UsbDevice device) throws SecurityException {
+	public UsbControlBlock openDevice(final UsbDevice device) throws SecurityException, IOException {
 		if (hasPermission(device)) {
 			UsbControlBlock result = mCtrlBlocks.get(device);
 			if (result == null) {
@@ -577,7 +578,13 @@ public final class USBMonitor {
 				final boolean createNew;
 				ctrlBlock = mCtrlBlocks.get(device);
 				if (ctrlBlock == null) {
-					ctrlBlock = new UsbControlBlock(USBMonitor.this, device);
+					try {
+						ctrlBlock = new UsbControlBlock(USBMonitor.this, device);
+					} catch (final IOException e) {
+						Log.w(TAG, "processConnect:failed to open device", e);
+						processCancel(device);
+						return;
+					}
 					mCtrlBlocks.put(device, ctrlBlock);
 					createNew = true;
 				} else {
@@ -909,15 +916,23 @@ public final class USBMonitor {
 
 		if (device != null) {
 			if (BuildCheck.isLollipop()) {
-				info.manufacturer = device.getManufacturerName();
-				info.product = device.getProductName();
-				info.serial = device.getSerialNumber();
+				try {
+					info.manufacturer = device.getManufacturerName();
+					info.product = device.getProductName();
+					info.serial = device.getSerialNumber();
+				} catch (final SecurityException e) {
+					Log.w(TAG, "updateDeviceInfo:failed to get device info", e);
+				}
 			}
 			if (BuildCheck.isMarshmallow()) {
 				info.usb_version = device.getVersion();
 			}
 			if ((manager != null) && manager.hasPermission(device)) {
 				final UsbDeviceConnection connection = manager.openDevice(device);
+				if (connection == null) {
+					Log.w(TAG, "updateDeviceInfo:openDevice failed, device may have been disconnected");
+					return info;
+				}
 				final byte[] desc = connection.getRawDescriptors();
 
 				if (TextUtils.isEmpty(info.usb_version)) {
@@ -987,11 +1002,15 @@ public final class USBMonitor {
 		 * @param monitor
 		 * @param device
 		 */
-		private UsbControlBlock(final USBMonitor monitor, final UsbDevice device) {
+		private UsbControlBlock(final USBMonitor monitor, final UsbDevice device) throws IOException {
 			if (DEBUG) Log.i(TAG, "UsbControlBlock:constructor");
 			mWeakMonitor = new WeakReference<USBMonitor>(monitor);
 			mWeakDevice = new WeakReference<UsbDevice>(device);
 			mConnection = monitor.mUsbManager.openDevice(device);
+			if (mConnection == null) {
+				throw new IOException("failed to open device " + device.getDeviceName()
+					+ ", device may have been disconnected or restricted");
+			}
 			mInfo = updateDeviceInfo(monitor.mUsbManager, device, null);
 			final String name = device.getDeviceName();
 			final String[] v = !TextUtils.isEmpty(name) ? name.split("/") : null;


### PR DESCRIPTION
## Summary

- Fix a race condition crash (~5% repro rate) when rapidly plugging/unplugging USB devices. The permission dialog may grant access to a device that has already been physically disconnected, causing `UsbManager.openDevice()` to return null and `getSerialNumber()` to throw an uncaught `SecurityException`, killing the process.
- Add null-checks and exception guards at four critical points in `USBMonitor` and adapt the Flutter plugin caller accordingly.

## Root Cause

When a USB device is unplugged while the system permission dialog is still showing, the following race occurs:



```
T1: Device attached → requestPermission() → system dialog shown
T2: Device physically unplugged → /dev/bus/usb/xxx removed
T3: User taps "Allow" → BroadcastReceiver gets EXTRA_PERMISSION_GRANTED=true
T4: processConnect() posts to mAsyncHandler (async delay widens the race window)
T5: UsbControlBlock constructor → openDevice() returns null (device gone)
T6: updateDeviceInfo() → getSerialNumber() → SecurityException → FATAL
```

## Changes

| File                                     | Change                                                       |
| ---------------------------------------- | ------------------------------------------------------------ |
| `USBMonitor.java` — `UsbControlBlock()`  | Check `openDevice()` return value; throw `IOException` if null instead of proceeding to `getSerialNumber()` |
| `USBMonitor.java` — `updateDeviceInfo()` | Wrap `getSerialNumber()`/`getManufacturerName()`/`getProductName()` in try-catch for `SecurityException`; early-return if `openDevice()` returns null |
| `USBMonitor.java` — `processConnect()`   | Catch `IOException` from `UsbControlBlock` constructor, log warning, and call `processCancel()` to notify listeners gracefully |
| `USBMonitor.java` — `openDevice()`       | Add `throws IOException` to method signature                 |
| `UvcCameraPlatform.java`                 | Adapt to new `IOException` on `openDevice()`, wrap as `IllegalStateException` |