### PR TITLE
Use PIXEL_FORMAT_YUV420SP to fix phots purple/blue colour cast

### DIFF
--- a/flutter/android/src/main/java/org/uvccamera/flutter/UvcCameraPlatform.java
+++ b/flutter/android/src/main/java/org/uvccamera/flutter/UvcCameraPlatform.java
@@ -979,7 +979,7 @@ import io.flutter.view.TextureRegistry;
                         outputFile,
                         resultHandler
                 ),
-                UVCCamera.PIXEL_FORMAT_NV21
+                UVCCamera.PIXEL_FORMAT_YUV420SP
         );
     }
 

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: uvccamera
 description: A USB Video Class (UVC) camera plugin for Flutter based on UVCCamera library for Android.
-version: 0.0.0-SNAPSHOT
+version: 0.0.13
 repository: https://github.com/alexey-pelykh/UVCCamera/tree/main/flutter
 issue_tracker: https://github.com/alexey-pelykh/UVCCamera/issues
 homepage: https://uvccamera.org


### PR DESCRIPTION
# Problem
Photos taken with takePicture() have a purple or blue colour cast. Videos are fine.

# Expected cause
a bug already documented in [saki4510t/UVCCamera#253](https://github.com/saki4510t/UVCCamera/issues/253): 
`takePicture()` requests frames via `setFrameCallback(..., PIXEL_FORMAT_NV21)`. The native C library contains two YUYV conversions whose names and actual outputs are mismatched 

`uvc_yuyv2yuv420SP` produces NV21 (V,U chroma byte order)
`uvc_yuyv2iyuv420SP` actually produces NV12 (U,V chroma byte order)
Requesting `PIXEL_FORMAT_NV21 (= 5)` routes to the function that produces NV12 data. Android's `YuvImage(data, ImageFormat.NV21)` then inverts U and V shifting reds to blue/purple in the output. also reported in in [saki4510t/UVCCamera#567](https://github.com/saki4510t/UVCCamera/issues/567).

# Fix
Change the pixel format constant from `PIXEL_FORMAT_NV21` to `PIXEL_FORMAT_YUV420SP` in takePicture(). `PIXEL_FORMAT_YUV420SP (= 4)` routes to the function that produces correctly-ordered NV21 data. `saveTakenPictureToFile()` is unchanged.

# Notes
If somebody hotfixed this already by post-processing photos to swap R/B channels they would see the inverse problem after this fix. Feels like it should be corrected, though? 
This fix only affects the takePicture() path. The frame callback is removed immediately after capture and is never active during video recording, so I don't think it will affect that. 